### PR TITLE
Fix request path

### DIFF
--- a/lib/rack/perftools_profiler/action.rb
+++ b/lib/rack/perftools_profiler/action.rb
@@ -17,7 +17,7 @@ module Rack::PerftoolsProfiler
     def self.for_env(env, profiler, middleware)
       request = Rack::Request.new(env)
       klass = 
-        case request.path
+        case request.path_info
         when '/__start__'
           StartProfiling
         when '/__stop__'


### PR DESCRIPTION
Rack::Request#path isn't available in some versions of Rack, but Rack::Request#path_info should always be available. Changed to use that.
