### PR TITLE
Change mode

### DIFF
--- a/lib/rack/perftools_profiler/profile_once.rb
+++ b/lib/rack/perftools_profiler/profile_once.rb
@@ -11,12 +11,13 @@ module Rack::PerftoolsProfiler
       super
       request = Rack::Request.new(@env)
       @times = (request.params.fetch('times') {1}).to_i
+      @mode = request.params['mode'] && request.params['mode'].to_sym
       check_printer_arg
       @new_env = delete_custom_params(@env)
     end
     
     def act
-      @profiler.profile do
+      @profiler.profile(@mode) do
         @times.times { @middleware.call_app(@new_env) }
       end
     end

--- a/lib/rack/perftools_profiler/profiler.rb
+++ b/lib/rack/perftools_profiler/profiler.rb
@@ -39,8 +39,8 @@ module Rack::PerftoolsProfiler
       raise ProfilerArgumentError, "Invalid option(s): #{options.keys.join(' ')}" unless options.empty?
     end
     
-    def profile
-      start
+    def profile(mode = nil)
+      start(mode)
       yield
     ensure
       stop
@@ -50,8 +50,13 @@ module Rack::PerftoolsProfiler
       ::File.delete(PROFILING_DATA_FILE) if ::File.exists?(PROFILING_DATA_FILE)
     end
     
-    def start
+    def start(mode = nil)
       PerfTools::CpuProfiler.stop
+      if (mode) # if a mode is passed, change to that mode and set env variables accordingly.
+        @mode = mode
+        unset_env_vars # clear the ones already set.
+      end  
+      set_env_vars
       PerfTools::CpuProfiler.start(PROFILING_DATA_FILE)
       self.profiling = true
     end

--- a/lib/rack/perftools_profiler/start_profiling.rb
+++ b/lib/rack/perftools_profiler/start_profiling.rb
@@ -2,8 +2,14 @@ module Rack::PerftoolsProfiler
 
   class StartProfiling < Action
 
+    def initialize(*args)
+      super
+      request = Rack::Request.new(@env)
+      @mode = request.params['mode'] && request.params['mode'].to_sym
+    end
+    
     def act
-      @profiler.start
+      @profiler.start(@mode)
     end
 
     def response


### PR DESCRIPTION
Patch allows you to change the mode on a per-request basis if desired. Use &mode=[objects|walltime], or anything else to reset it to the normal mode. The underlying library (from perftools.rb) does allow you to set which one you want by the environment variable on a per-start() basis.
