### PR TITLE
Fix shell injection attack.

### DIFF
--- a/lib/rack/perftools_profiler/action.rb
+++ b/lib/rack/perftools_profiler/action.rb
@@ -17,18 +17,22 @@ module Rack::PerftoolsProfiler
     def self.for_env(env, profiler, middleware)
       request = Rack::Request.new(env)
       klass = 
-        case request.path_info
-        when %r{/__start__$}
-          StartProfiling
-        when %r{/__stop__$}
-          StopProfiling
-        when %r{/__data__$}
-          ReturnData
+        if ENV["PROFILE_PASSWORD"] && request.GET['profile'] != ENV["PROFILE_PASSWORD"]
+          CallAppDirectly
         else
-          if ProfileOnce.has_special_param?(request)
-            ProfileOnce
+          case request.path_info
+          when %r{/__start__$}
+            StartProfiling
+          when %r{/__stop__$}
+            StopProfiling
+          when %r{/__data__$}
+            ReturnData
           else
-            CallAppDirectly
+            if ProfileOnce.has_special_param?(request)
+              ProfileOnce
+            else
+              CallAppDirectly
+            end
           end
         end
       klass.new(env, profiler, middleware)

--- a/lib/rack/perftools_profiler/profiler.rb
+++ b/lib/rack/perftools_profiler/profiler.rb
@@ -84,10 +84,14 @@ module Rack::PerftoolsProfiler
       printer = (options.fetch('printer') {@printer}).to_sym
       ignore = options.fetch('ignore') { nil }
       focus = options.fetch('focus') { nil }
+      nodecount = options.fetch('nodecount') { nil }
+      nodefraction = options.fetch('nodefraction') { nil }
       if ::File.exists?(PROFILING_DATA_FILE)
         args = ["--#{printer}"]
-        args << " --ignore=#{ignore}" if ignore
-        args << " --focus=#{focus}" if focus
+        args << "--ignore=#{ignore}" if ignore
+        args << "--focus=#{focus}" if focus
+        args << "--nodecount=#{nodecount}" if nodecount
+        args << "--nodefraction=#{nodefraction}" if nodefraction
         args << PROFILING_DATA_FILE
         cmd = ["pprof.rb"] + args
         cmd = ["bundle", "exec"] + cmd if @bundler

--- a/lib/rack/perftools_profiler/profiler_middleware.rb
+++ b/lib/rack/perftools_profiler/profiler_middleware.rb
@@ -9,7 +9,8 @@ module Rack::PerftoolsProfiler
       :text => 'text/plain',
       :gif => 'image/gif',
       :pdf => 'application/pdf',
-      :callgrind => 'text/plain'
+      :callgrind => 'text/plain',
+      :raw => 'application/octet-stream'
     }
     
     PRINTERS = PRINTER_CONTENT_TYPE.keys

--- a/lib/rack/perftools_profiler/profiler_middleware.rb
+++ b/lib/rack/perftools_profiler/profiler_middleware.rb
@@ -59,7 +59,7 @@ module Rack::PerftoolsProfiler
         'Content-Type' => PRINTER_CONTENT_TYPE[printer],
         'Content-Length' => content_length(body)
       }
-      if printer==:pdf || printer ==:raw
+      if printer ==:raw
         filetype = printer
         filename='profile_data'
         headers['Content-Disposition'] = %(attachment; filename="#{filename}.#{filetype}")

--- a/lib/rack/perftools_profiler/profiler_middleware.rb
+++ b/lib/rack/perftools_profiler/profiler_middleware.rb
@@ -59,7 +59,7 @@ module Rack::PerftoolsProfiler
         'Content-Type' => PRINTER_CONTENT_TYPE[printer],
         'Content-Length' => content_length(body)
       }
-      if printer==:pdf
+      if printer==:pdf || printer ==:raw
         filetype = printer
         filename='profile_data'
         headers['Content-Disposition'] = %(attachment; filename="#{filename}.#{filetype}")

--- a/test/multiple_request_profiling_test.rb
+++ b/test/multiple_request_profiling_test.rb
@@ -176,6 +176,17 @@ class MultipleRequestProfilingTest < Test::Unit::TestCase
       
     end
 
+    context "when the nodefraction parameter is specified" do
+      should "call pprof.rb with nodefraction" do
+        status = stub_everything(:exitstatus => 0)
+        profiled_app = Rack::PerftoolsProfiler.new(@app)
+        custom_env = Rack::MockRequest.env_for('/method1', :params => 'profile=true&nodefraction=160')
+        Open4.expects(:popen4).with('pprof.rb', '--text',  '--nodefraction=160', '/tmp/rack_perftools_profiler.prof').returns(status)
+        profiled_app.call(custom_env)
+      end
+    end
+
+
     context "when overriding profiling mode" do
 
       should "default to configured mode if mode is empty string" do

--- a/test/multiple_request_profiling_test.rb
+++ b/test/multiple_request_profiling_test.rb
@@ -158,7 +158,7 @@ class MultipleRequestProfilingTest < Test::Unit::TestCase
       should "call pprof.rb using 'bundle' command if bundler is set" do
         status = stub_everything(:exitstatus => 0)
         profiled_app = Rack::PerftoolsProfiler.new(@app, :bundler => true)
-        Open4.expects(:popen4).with(regexp_matches(/^bundle exec pprof\.rb/)).returns(status)
+        Open4.expects(:popen4).with('bundle', 'exec', 'pprof.rb', '--text', '/tmp/rack_perftools_profiler.prof').returns(status)
         profile(profiled_app)
       end
 

--- a/test/single_request_profiling_test.rb
+++ b/test/single_request_profiling_test.rb
@@ -123,6 +123,16 @@ class SingleRequestProfilingTest < Test::Unit::TestCase
       
     end
 
+    context "when the nodecount parameter is specified" do
+      should "call pprof.rb with nodecount" do
+        status = stub_everything(:exitstatus => 0)
+        profiled_app = Rack::PerftoolsProfiler.new(@app)
+        custom_env = Rack::MockRequest.env_for('/method1', :params => 'profile=true&nodecount=160')
+        Open4.expects(:popen4).with('pprof.rb', '--text',  '--nodecount=160', '/tmp/rack_perftools_profiler.prof').returns(status)
+        profiled_app.call(custom_env)
+      end
+    end
+
     context "when overriding profiling mode" do
 
       should "default to configured mode if mode is empty string" do

--- a/test/single_request_profiling_test.rb
+++ b/test/single_request_profiling_test.rb
@@ -105,7 +105,7 @@ class SingleRequestProfilingTest < Test::Unit::TestCase
       should "call pprof.rb using 'bundle' command if bundler is set" do
         status = stub_everything(:exitstatus => 0)
         profiled_app = Rack::PerftoolsProfiler.new(@app, :bundler => true)
-        Open4.expects(:popen4).with(regexp_matches(/^bundle exec pprof\.rb/)).returns(status)
+        Open4.expects(:popen4).with('bundle', 'exec', 'pprof.rb', '--text', '/tmp/rack_perftools_profiler.prof').returns(status)
         profiled_app.call(@profiled_request_env)
       end
 

--- a/test/single_request_profiling_test.rb
+++ b/test/single_request_profiling_test.rb
@@ -312,4 +312,25 @@ class SingleRequestProfilingTest < Test::Unit::TestCase
 
   end
 
+  context "when a profile password is required" do
+    should "not profile unless the parameter matches" do
+      ENV["PROFILE_PASSWORD"] = 'secret_password'
+      app = @app.clone
+      env = Rack::MockRequest.env_for('/', :params => {'profile' => 'true'})
+      status, headers, body = Rack::PerftoolsProfiler.new(app, :default_printer => 'pdf').call(env)
+      assert_equal 200, status
+      assert_equal 'text/plain', headers['Content-Type']
+      assert_equal 'Oh hai der', RackResponseBody.new(body).to_s
+      ENV.delete 'PROFILE_PASSWORD'
+    end
+
+    should "profile if the parameter matches" do
+      ENV["PROFILE_PASSWORD"] = 'secret_password'
+      env = Rack::MockRequest.env_for('/', :params => 'profile=secret_password&printer=gif')
+      _, headers, _ = Rack::PerftoolsProfiler.new(@app, :default_printer => 'pdf').call(env)
+      assert_equal 'image/gif', headers['Content-Type']
+      ENV.delete 'PROFILE_PASSWORD'
+    end
+  end
+
 end


### PR DESCRIPTION
The ignore and focus parameters are not sanitised before being passed to the shell.

This fix relies on https://github.com/tmm1/perftools.rb/pull/29.
