### PR TITLE
When there's a password set and no profile parameters, just skip to calling the app directly.

### DIFF
--- a/lib/rack/perftools_profiler/action.rb
+++ b/lib/rack/perftools_profiler/action.rb
@@ -17,7 +17,9 @@ module Rack::PerftoolsProfiler
     def self.for_env(env, profiler, middleware)
       request = Rack::Request.new(env)
       klass = 
-        if !profiler.password_valid?(request.GET['profile'])
+        if profiler.should_check_password? && ! request.GET.key?('profile')
+          CallAppDirectly
+        elsif !profiler.password_valid?(request.GET['profile'])
           ReturnPasswordError
         else
           case request.path_info

--- a/lib/rack/perftools_profiler/profiler.rb
+++ b/lib/rack/perftools_profiler/profiler.rb
@@ -58,7 +58,11 @@ module Rack::PerftoolsProfiler
     def password_valid?(password)
       @password.nil? || password == @password
     end
-    
+
+    def should_check_password?
+      ! @password.nil?
+    end
+
     def start(mode = nil)
       ensure_mode_is_changeable(mode) if mode
       PerfTools::CpuProfiler.stop

--- a/test/single_request_profiling_test.rb
+++ b/test/single_request_profiling_test.rb
@@ -325,6 +325,18 @@ class SingleRequestProfilingTest < Test::Unit::TestCase
   end
 
   context "when a profile password is required" do
+    should "call the app directly when 'profile' is not a request parameter" do
+      env = Rack::MockRequest.env_for('/', :params => {})
+      app = lambda do |env|
+        request = Rack::Request.new(env)
+        assert_equal( {}, request.GET)
+        [200, {}, ["HI"]]
+      end
+      status, headers, body = Rack::PerftoolsProfiler.new(app, :default_printer => 'pdf', :password => "secret_password").call(env)
+      assert_equal 200, status
+      assert_equal ["HI"], body
+    end
+
     should "error if password does not match" do
       app = @app.clone
       env = Rack::MockRequest.env_for('/', :params => {'profile' => 'true'})


### PR DESCRIPTION
fixes issue #13
